### PR TITLE
Dashboard new activity

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,7 +1,11 @@
 class ActivitiesController < ApplicationController
 
   def create
-    
+    serialized_activity = ActivitySerializer.serialize_activity(params[:brewery_name],params[:drink_type], params[:user_id])
+    unformatted_activity = BEService.create_activity(serialized_activity)
+    activity = Activity.new(unformatted_activity[:data])
+    params[:activity_id] = activity.id
+    redirect_to "/activities/#{activity.id}"
   end
 
   def show

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,13 +1,15 @@
 class SessionsController < ApplicationController
   def create
     user_data = StravaService.authorize_user_account(params[:code])
+    if params[:error] == 'access_denied'
+      redirect_to '/'
+    else
+      serialized_user_data = StravaAuthSerializer.serialize(user_data)
+      user_parsed_json = BEService.login_user(serialized_user_data)
 
-    serialized_user_data = StravaAuthSerializer.serialize(user_data)
-
-    user_parsed_json = BEService.login_user(serialized_user_data)
-
-    @user = User.new(user_parsed_json)
-    session[:user_id] = @user.id
-    redirect_to '/dashboard'
+      @user = User.new(user_parsed_json)
+      session[:user_id] = @user.id
+      redirect_to '/dashboard'
+    end
   end
 end

--- a/app/poros/activity.rb
+++ b/app/poros/activity.rb
@@ -22,10 +22,10 @@ class Activity
     @dollars_saved = activity_data[:attributes][:dollars_saved]
     @lbs_carbon_saved = activity_data[:attributes][:lbs_carbon_saved]
     @user_id = activity_data[:attributes][:user_id]
-    @created_at = activity_data[:attributes][:created_at]
+    @created_at = format_date(activity_data[:attributes][:created_at])
   end
 
-  def format_date
-    DateTime.parse(@created_at).strftime("%A, %B %d, %Y")  
+  def format_date(date)
+    DateTime.parse(date).strftime("%A, %B %d, %Y")
   end
 end

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -1,0 +1,11 @@
+class ActivitySerializer
+  def self.serialize_activity(brewery_name, drink_type, user_id)
+    {
+      data: {
+        brewery_name: brewery_name,
+        drink_type: drink_type,
+        user_id: user_id
+      }
+    }
+  end
+end

--- a/app/services/be_service.rb
+++ b/app/services/be_service.rb
@@ -45,12 +45,12 @@ class BEService
     JSON.parse(response.body, symbolize_names: true)
   end
 
-  #this is not functional at this time
   def self.create_activity(activity_data)
     response = conn.post("/api/v1/activities") do |req|
       req.headers[:CONTENT_TYPE] = "application/json"
       req.body = JSON.generate(activity: activity_data)
     end
+    JSON.parse(response.body, symbolize_names: true)
   end 
 
   def self.find_activity(activity_id)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,8 +31,14 @@
   <% end %>
 </div>
 
-<div id="new_activity">
+<div id="new_activity" style="position: absolute; top: 100px; left: 350px; width: 500px; height:125px; background-color: olive;">
   <h3>Did you make it to a brewery?</h3>
+  <%= form_with url: '/activities', method: :post, local: true do |f| %>
+    <%= f.select :brewery_name, @user.breweries.map {|brewery| brewery.name } %>
+    <%= f.select :drink_type, ['IPA', 'Pilsner', "Light Beer"] %>
+    <%= f.hidden_field :user_id, value: @user.id %>
+    <%= f.submit 'Log Activity' %>
+  <% end %>
 </div>
 
 <div id="recent_activities" style="position: absolute; top: 300px; left: 350px; width: 500px; background-color: azure;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   get '/auth/strava/callback', to: 'sessions#create'
 
   get "/activities/:activity_id", to: "activities#show"
+  post '/activities', to: 'activities#create'
 end

--- a/spec/facades/activities_facade_spec.rb
+++ b/spec/facades/activities_facade_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ActivitiesFacade do
 
     describe "#find_an_activity" do
       it "returns an Activity object that matches the search criteria" do
-        activities_data = {data: {id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 5}}}
+        activities_data = {data: {id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 5, created_at: "2023-01-10 04:24:35"}}}
 
         stub_request(:get, "https://be-bik-n-bru.herokuapp.com/api/v1/activities/1").to_return(body: activities_data.to_json)
         

--- a/spec/facades/users_facade_spec.rb
+++ b/spec/facades/users_facade_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe UsersFacade do
          {:id=>"alesong-brewing-and-blending-eugene",
           :type=>"brewery",
           :attributes=>{:name=>"Alesong Brewing and Blending", :street_address=>"1000 Conger St Ste C", :city=>"Eugene", :state=>"Oregon", :zipcode=>"97402-2950", :phone=>"5419723303", :website_url=>"http://www.alesongbrewing.com"}}]}
-        activities_data = {data:[{id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 5}},
-          {id:'1', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 5}}]}
+        activities_data = {data:[{id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 5, created_at: "2023-01-10 04:24:35"}},
+          {id:'1', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 5, created_at: "2023-01-10 04:24:35"}}]}
   
           
           

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -15,13 +15,17 @@ RSpec.describe 'The Dashboard Show Page', type: :feature do
         :type=>"brewery",
         :attributes=>{:name=>"Alesong Brewing and Blending", :street_address=>"1000 Conger St Ste C", :city=>"Eugene", :state=>"Oregon", :zipcode=>"97402-2950", :phone=>"5419723303", :website_url=>"http://www.alesongbrewing.com"}}]}
       
-      @activities_data = {data:[{id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 99}},
-        {id:'1', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 99}}]}
+      @activities_data = {data:[{id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 99, created_at: "2023-01-10 04:24:35"}},
+        {id:'2', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 99, created_at: "2023-01-10 04:24:35"}}]}
 
+      new_activity_data = {data: {id:'3', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 5, created_at: "2023-01-10 04:24:35"}}}
+      stub_request(:get, "https://be-bik-n-bru.herokuapp.com/api/v1/activities/3").to_return(body: new_activity_data.to_json)
+      stub_request(:post, "https://be-bik-n-bru.herokuapp.com/api/v1/activities").to_return(body: new_activity_data.to_json)
       stub_request(:any, 'https://be-bik-n-bru.herokuapp.com/api/v1/users/99').to_return(body: @user_data.to_json)
       stub_request(:any, 'https://be-bik-n-bru.herokuapp.com/api/v1/users/99/badges').to_return(body: @user_badges.to_json)
       stub_request(:get, 'https://be-bik-n-bru.herokuapp.com/api/v1/breweries/99').to_return(body: @brewery_data.to_json)
       stub_request(:get, 'https://be-bik-n-bru.herokuapp.com/api/v1/users/99/activities').to_return(body: @activities_data.to_json)
+      stub_request(:post, 'https://be-bik-n-bru.herokuapp.com/api/v1/users/99/activities').to_return(body: @activities_data.to_json)
         
       page.set_rack_session(user_id: '99')
       visit '/dashboard'
@@ -60,6 +64,10 @@ RSpec.describe 'The Dashboard Show Page', type: :feature do
       redirected to the Activity Show Page' do
         within("#new_activity") do
           expect(page).to have_content('Did you make it to a brewery?')
+          select('Agrarian Ales, LLC', from: 'brewery_name')
+          select('IPA', from: 'drink_type')
+          click_button ('Log Activity')
+          expect(current_path).to eq('/activities/3')
         end
       end
     end

--- a/spec/poros/activity_spec.rb
+++ b/spec/poros/activity_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Activity do
   describe 'initialize' do
     it 'has readable attributes' do
-      activity_data = {id:'1', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 5}}
+      activity_data = {id:'1', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 5, created_at: "2023-01-10 04:24:35"}}
       activity = Activity.new(activity_data)
 
       expect(activity.id).to eq(activity_data[:id])
@@ -15,6 +15,7 @@ RSpec.describe Activity do
       expect(activity.dollars_saved).to eq(activity_data[:attributes][:dollars_saved])
       expect(activity.lbs_carbon_saved).to eq(activity_data[:attributes][:lbs_carbon_saved])
       expect(activity.user_id).to eq(activity_data[:attributes][:user_id])
+      expect(activity.created_at).to eq("Tuesday, January 10, 2023")
     end
   end
 end

--- a/spec/poros/user_detail_spec.rb
+++ b/spec/poros/user_detail_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe UserDetail do
   
   @breweries = [b1, b2]
 
-  activity1 = Activity.new({id:'1', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 5}})
-  activity2 = Activity.new({id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 5}})
+  activity1 = Activity.new({id:'1', attributes:{brewery_name:'Wild Corgi Pub', distance: 5.1, calories: 521, num_drinks: 3, drink_type: 'Domestic', dollars_saved: 2.71, lbs_carbon_saved: 1.6, user_id: 5, created_at: "2023-01-10 04:24:35"}})
+  activity2 = Activity.new({id:'1', attributes:{brewery_name:'Wagon Wheel', distance: 3.7, calories: 400, num_drinks: 2, drink_type: 'IPA', dollars_saved: 1.97, lbs_carbon_saved: 1.2, user_id: 5, created_at: "2023-01-10 04:24:35"}})
 
   @activities = [activity1, activity2]
   end

--- a/spec/serializers/activity_serializer_spec.rb
+++ b/spec/serializers/activity_serializer_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe ActivitySerializer do
+  describe 'class methods' do
+    describe '#serialize_activity' do
+      it 'returns a serialized activity' do
+        activity = ActivitySerializer.serialize_activity('The Pad', 'Pilsner', '1')
+
+        expect(activity).to be_a Hash
+        expect(activity[:data]).to be_a Hash
+        expect(activity[:data][:brewery_name]).to eq('The Pad')
+        expect(activity[:data][:drink_type]).to eq('Pilsner')
+        expect(activity[:data][:user_id]).to eq('1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updated Activity PORO to include `created_at` attribute and the corresponding tests.

Added `new_activity` section on user Dashboard. Happy path fully tested, but an edge case that needs resolving is BE error handling of a user without any activities (currently returning a 500 error) as well as a sad path for the FE.

Currently the Brewery dropdown shows a max of 10 breweries (the number in the UserDetail Breweries attribute). It probably makes sense to move the .first(10) from the facade to the view (for the breweries side panel) so more breweries are available for the dropdown.